### PR TITLE
Export "newerBuild" so that BO REST can use it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/CancelledCause.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/CancelledCause.java
@@ -25,6 +25,7 @@ package org.jenkinsci.plugins.pipeline.milestone;
 
 import hudson.model.Run;
 import jenkins.model.CauseOfInterruption;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * Records that a build was canceled because it reached a milestone but a newer build already passed it, or
@@ -47,6 +48,11 @@ public final class CancelledCause extends CauseOfInterruption {
         this.newerBuild = newerBuild;
         // No display name available, use what we have at this point
         this.displayName = newerBuild;
+    }
+
+    @Exported
+    public String getNewerRunId() {
+        return newerBuild;
     }
 
     public Run<?,?> getNewerBuild() {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/CancelledCause.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/CancelledCause.java
@@ -27,6 +27,8 @@ import hudson.model.Run;
 import jenkins.model.CauseOfInterruption;
 import org.kohsuke.stapler.export.Exported;
 
+import javax.annotation.Nullable;
+
 /**
  * Records that a build was canceled because it reached a milestone but a newer build already passed it, or
  * a newer build {@link Milestone#wentAway(Run)} from the last milestone the build passed.
@@ -39,24 +41,31 @@ public final class CancelledCause extends CauseOfInterruption {
 
     private final String displayName;
 
+    private final int newerBuildNumber;
+
     CancelledCause(Run<?,?> newerBuild) {
+        this.newerBuildNumber = newerBuild.getNumber();
         this.newerBuild = newerBuild.getExternalizableId();
         this.displayName = newerBuild.getDisplayName();
     }
 
-    CancelledCause(String newerBuild) {
-        this.newerBuild = newerBuild;
-        // No display name available, use what we have at this point
-        this.displayName = newerBuild;
+    CancelledCause(String displayName, int newerBuildNumber) {
+        this.newerBuild = null;
+        this.displayName = displayName;
+        this.newerBuildNumber = newerBuildNumber;
     }
 
     @Exported
-    public String getNewerRunId() {
-        return newerBuild;
+    public int getNewerRunId() {
+        return newerBuildNumber;
     }
 
+    /**
+     * @return run or null if it does not exist
+     */
+    @Nullable
     public Run<?,?> getNewerBuild() {
-        return Run.fromExternalizableId(newerBuild);
+        return newerBuild != null ? Run.fromExternalizableId(newerBuild) : null;
     }
 
     @Override public String getShortDescription() {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -268,7 +268,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
                 Run<?, ?> olderInSightBuild = r.getParent().getBuildByNumber(inSightNumber);
                 Executor e = olderInSightBuild.getExecutor();
                 if (e != null) {
-                    e.interrupt(Result.NOT_BUILT, new CancelledCause(r.getExternalizableId()));
+                    e.interrupt(Result.NOT_BUILT, new CancelledCause(r));
                 } else {
                     LOGGER.log(WARNING, "could not cancel an older flow because it has no assigned executor");
                 }
@@ -292,11 +292,9 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
         if (context.isReady()) {
             println(context, "Canceled since build #" + build + " already got here");
             Run<?, ?> r = context.get(Run.class);
-            String job = "";
-            if (r != null) { // it should be always non-null at this point, but let's do a defensive check
-                job = r.getParent().getFullName();
-            }
-            throw new FlowInterruptedException(Result.NOT_BUILT, new CancelledCause(job + "#" + build));
+            // Defensive check as the previous run may have been deleted
+            CancelledCause cause = r != null ? new CancelledCause(r) : new CancelledCause("#" + build, build);
+            throw new FlowInterruptedException(Result.NOT_BUILT, cause);
         } else {
             LOGGER.log(WARNING, "cannot cancel dead #" + build);
         }


### PR DESCRIPTION
@amuniz very quick one to make the `CancelledCause` serialize better via Blue Ocean REST API.

Related to https://issues.jenkins-ci.org/browse/JENKINS-40871