### PR TITLE
[JENKINS-43353] Demo of aborting any running build(s) when we start a new one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.23</version>
+        <version>2.37</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -12,7 +12,7 @@
     <version>1.4-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Milestone Step</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Milestone+Step+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Milestone+Step+Plugin</url>
     <description>Plugin that provides the milestone step</description>
 
     <licenses>


### PR DESCRIPTION
[JENKINS-43353](https://issues.jenkins-ci.org/browse/JENKINS-43353)

Test case demonstrates desired behavior, along with a crude workaround based on the current step.

@reviewbybees