### PR TITLE
allow unsafe execution of milestone inside a parallel branch

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep.java
@@ -59,6 +59,11 @@ public class MilestoneStep extends AbstractStepImpl {
      */
     private Integer ordinal;
 
+    /**
+     * Optional unsafe.
+     */
+    private boolean unsafe;
+
     @DataBoundConstructor
     public MilestoneStep(Integer ordinal) {
         this.ordinal = ordinal;
@@ -69,6 +74,11 @@ public class MilestoneStep extends AbstractStepImpl {
         this.label = Util.fixEmpty(label);
     }
 
+    @DataBoundSetter
+    public void setUnsafe(boolean unsafe) {
+        this.unsafe = unsafe;
+    }
+
     @CheckForNull
     public String getLabel() {
         return label;
@@ -77,6 +87,10 @@ public class MilestoneStep extends AbstractStepImpl {
     @CheckForNull
     public Integer getOrdinal() {
         return ordinal;
+    }
+
+    public boolean isUnsafe() {
+        return unsafe;
     }
 
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -86,7 +86,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
      */
     private synchronized int processOrdinal() throws AbortException {
         List<FlowNode> heads = node.getExecution().getCurrentHeads();
-        if (heads.size() > 1) {  // TA-DA!  We're inside a parallel, which is forbidden.
+        if (heads.size() > 1 && !step.isUnsafe()) {  // TA-DA!  We're inside a parallel, which is forbidden.
             throw new AbortException("Using a milestone step inside parallel is not allowed");
         }
 

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/config.jelly
@@ -31,4 +31,7 @@ THE SOFTWARE.
     <f:entry field="ordinal" title="Ordinal">
         <f:number clazz="positive-number"/>
     </f:entry>
+    <f:entry field="unsafe" title="Unsafe">
+        <f:checkbox />
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/help-unsafe.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/help-unsafe.html
@@ -1,0 +1,8 @@
+<p>
+    An optional flag to allow unsafe execution of the milestone step.
+    <strong>Do not set unless you understand the risks.</strong>
+</p>
+<p>
+    Currently this will allow the execution of a milestone step within a parallel step.
+    It is assumed only 1 branch can contain a milestone step.
+</p>

--- a/src/test/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepTest.java
@@ -178,6 +178,47 @@ public class MilestoneStepTest {
         });
     }
 
+    @Test
+    public void unsafeMilestoneAllowedInsideParallel() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(
+                        "sleep 1\n" +
+                        "parallel one: { echo 'First' }, two: { \n" +
+                        "  node {\n" +
+                        "    echo 'Test'\n" +
+                        "  }\n" +
+                        "  milestone unsafe: true\n" +
+                        "}\n" +
+                        "milestone()\n"));
+                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+                p.setDefinition(new CpsFlowDefinition(
+                        "sleep 1\n" +
+                        "parallel one: { echo 'First' }, two: { \n" +
+                        "  echo 'Pre-node'\n" +
+                        "  node {\n" +
+                        "    milestone unsafe: true\n" +
+                        "  }\n" +
+                        "}\n" +
+                        "milestone()\n"));
+                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+
+                p.setDefinition(new CpsFlowDefinition(
+                        "sleep 1\n" +
+                        "parallel one: { echo 'First' }, two: { \n" +
+                        "  echo 'Pre-node'\n" +
+                        "  node {\n" +
+                        "    echo 'Inside node'\n" +
+                        "  }\n" +
+                        "}\n" +
+                        "milestone()\n"));
+                story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+            }
+        });
+    }
+
     @Issue("JENKINS-38464")
     @Test
     public void milestoneAllowedOutsideParallel() {


### PR DESCRIPTION
I really need to use the milestone step within a parallel branch to be efficient.

So basically I want to run integration tests and in parallel generate the maven site and do other stuff. The resources are limited to run integration tests so I use the lock plugin in reverse order.

Right now I need to lock before the parallel step and delay the documentation generation until I acquire the lock and this is not efficient (as sometimes the other branches could have completed while waiting for the lock).

So I've added an "unsafe" parameter to the milestone step that if selected will allow it within a parallel branch. The help file explains this should be used only if a single branch has a milestone step.

Let me know what you think.