### PR TITLE
Update plugin POM

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-7</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.48</version>
+        <version>3.50</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>pipeline-milestone-step</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Milestone Step</name>
     <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Milestone+Step+Plugin</url>
@@ -25,7 +25,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+      <tag>${scmTag}</tag>
     </scm>
     <repositories>
         <repository>
@@ -40,6 +40,8 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
+        <revision>1.4</revision>
+        <changelist>-SNAPSHOT</changelist>
         <jenkins.version>1.642.3</jenkins.version>
         <java.level>7</java.level>
         <workflow-support-plugin.version>2.13</workflow-support-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
     <properties>
         <revision>1.4</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>1.642.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <workflow-support-plugin.version>2.13</workflow-support-plugin.version>
         <workflow-cps-plugin.version>2.28</workflow-cps-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.37</version>
+        <version>3.48</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
@@ -41,6 +41,7 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
+        <java.level>7</java.level>
         <workflow-support-plugin.version>2.13</workflow-support-plugin.version>
         <workflow-cps-plugin.version>2.28</workflow-cps-plugin.version>
     </properties>


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 2.37 to 3.48.

See [the changelog](https://github.com/jenkinsci/plugin-pom/blob/master/CHANGELOG.md) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-2.37...plugin-3.48).