### PR TITLE
[JENKINS-60354] Mark thrown FlowInterruptedException as an actual interruption

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.3'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.9</version>
+            <version>2.22-rc550.2870bd01d2ff</version> <!-- TODO: https://github.com/jenkinsci/workflow-step-api-plugin/pull/51 -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.37</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>pipeline-milestone-step</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Milestone Step</name>
     <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Milestone+Step+Plugin</url>
@@ -25,7 +25,7 @@
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
+        <tag>${scmTag}</tag>
     </scm>
     <repositories>
         <repository>
@@ -40,7 +40,10 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>1.642.3</jenkins.version>
+        <revision>1.4</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <jenkins.version>2.138.4</jenkins.version>
+        <java.level>8</java.level>
         <workflow-support-plugin.version>2.13</workflow-support-plugin.version>
         <workflow-cps-plugin.version>2.28</workflow-cps-plugin.version>
     </properties>

--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -292,7 +292,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
             if (r != null) { // it should be always non-null at this point, but let's do a defensive check
                 job = r.getParent().getFullName();
             }
-            throw new FlowInterruptedException(Result.NOT_BUILT, new CancelledCause(job + "#" + build));
+            throw new FlowInterruptedException(Result.NOT_BUILT, true, new CancelledCause(job + "#" + build));
         } else {
             LOGGER.log(WARNING, "cannot cancel dead #" + build);
         }


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354) and https://github.com/jenkinsci/workflow-step-api-plugin/pull/51.

Also includes some required POM updates that happen to subsume #21.