### PR TITLE
[JENKINS-61296] Add optional superseded build result property

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/Milestone.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/Milestone.java
@@ -30,6 +30,7 @@ import javax.annotation.CheckForNull;
 
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 
+import hudson.model.Result;
 import hudson.model.Run;
 
 class Milestone {
@@ -38,6 +39,11 @@ class Milestone {
      * Milestone ordinal.
      */
     final Integer ordinal;
+
+    /**
+     * Superseded build result.
+     */
+    final Result result;
 
     /**
      * Numbers of builds that passed this milestone but haven't passed the next one.
@@ -50,12 +56,13 @@ class Milestone {
     @CheckForNull
     Integer lastBuild;
 
-    Milestone(Integer ordinal) {
+    Milestone(Integer ordinal, Result result) {
         this.ordinal = ordinal;
+        this.result = result;
     }
 
     @Override public String toString() {
-        return "Milestone[inSight=" + inSight + "]";
+        return "Milestone[ordinal=" + ordinal + ", inSight=" + inSight + ", " + result + "]";
     }
 
     public void pass(StepContext context, Run<?, ?> build) {

--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep.java
@@ -37,6 +37,7 @@ import org.kohsuke.stapler.DataBoundSetter;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import hudson.Extension;
 import hudson.Util;
+import hudson.model.Result;
 
 /**
  * This step can be used to grant:
@@ -58,6 +59,11 @@ public class MilestoneStep extends AbstractStepImpl {
      * Optional ordinal.
      */
     private Integer ordinal;
+
+    /**
+     * Optional result for superseded builds.
+     */
+    private Result result = Result.NOT_BUILT;
 
     /**
      * Optional unsafe.
@@ -91,6 +97,16 @@ public class MilestoneStep extends AbstractStepImpl {
 
     public boolean isUnsafe() {
         return unsafe;
+    }
+
+    @CheckForNull
+    public Result getResult() {
+        return result;
+    }
+
+    @DataBoundSetter
+    public void setResult(String result) {
+        this.result = Result.fromString(result);
     }
 
     @Extension

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/config.jelly
@@ -34,4 +34,7 @@ THE SOFTWARE.
     <f:entry field="unsafe" title="Unsafe">
         <f:checkbox />
     </f:entry>
+    <f:entry field="result" title="Superseded build result">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/help-result.html
+++ b/src/main/resources/org/jenkinsci/plugins/pipeline/milestone/MilestoneStep/help-result.html
@@ -1,0 +1,4 @@
+<p>
+    An optional property that allows to override the build result that superseded builds will receive.
+    Default is <code>NOT_BUILT</code>.
+</p>


### PR DESCRIPTION
The `milestone` step cancels older builds with result `NOT_BUILT`.

It should be possible to optionally override this behavior and set it to something else, e.g. `ABORTED`.

Use case:

I want to cancel older PR builds by using this code:
```
def buildNumber = env.BUILD_NUMBER as int
if (buildNumber > 1) {
  // aborting previous builds by superseding their milestone
  milestone(buildNumber - 1)
}
// creating milestone for current build
milestone(buildNumber)
```

This works as expected, older builds are cancelled with result `NOT_BUILT`. Now I am using the Bitbucket Branch Source Plugin to automatically report the build status to Bitbucket. In that plugin, the status `NOT_BUILT` gets mapped to `SUCCESS` in Bitbucket. If I have a Merge Check to prevent merging of the PR, I now have a situation that the build result is `SUCCESS` even though it never ran.

So I want to be able to customize the cancelled build's result by overriding it in the milestone step. 
The new parameter is optional, and if not overriden, the behavior should be exactly as it was before. 
