### PR TITLE
Cancelling of concurrent pipeline run due to milestone wrongly claims that user aborted

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -292,7 +292,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
             if (r != null) { // it should be always non-null at this point, but let's do a defensive check
                 job = r.getParent().getFullName();
             }
-            throw new FlowInterruptedException(Result.NOT_BUILT, new CancelledCause(job + "#" + build));
+            throw new FlowInterruptedException(Result.NOT_BUILT, false, new CancelledCause(job + "#" + build));
         } else {
             LOGGER.log(WARNING, "cannot cancel dead #" + build);
         }


### PR DESCRIPTION
See [JENKINS-67067](https://issues.jenkins.io/browse/JENKINS-67067) "Cancelling of concurrent pipeline run due to milestone wrongly claims that user aborted via FlowInterruptedException#actualInterruption"

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue