### PR TITLE
Replace deprecated calls to Jenkins.getActiveInstance

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -126,7 +126,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
     }
 
     private static Map<String, Map<Integer, Milestone>> getMilestonesByOrdinalByJob() {
-        return ((MilestoneStep.DescriptorImpl) Jenkins.getActiveInstance().getDescriptorOrDie(MilestoneStep.class)).getMilestonesByOrdinalByJob();
+        return ((MilestoneStep.DescriptorImpl) Jenkins.get().getDescriptorOrDie(MilestoneStep.class)).getMilestonesByOrdinalByJob();
     }
 
     private synchronized void tryToPass(Run<?,?> r, StepContext context, int ordinal) throws IOException, InterruptedException {
@@ -318,7 +318,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
     }
 
     private static void save() {
-        Jenkins.getActiveInstance().getDescriptorOrDie(MilestoneStep.class).save();
+        Jenkins.get().getDescriptorOrDie(MilestoneStep.class).save();
     }
 
     @Extension


### PR DESCRIPTION
Replaces usage of the deprecated `Jenkins.getActiveInstance` with the equivalent `Jenkins.get`

<!-- Please describe your pull request here. -->


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
