### PR TITLE
Deprecating `LabelAction`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneAction.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneAction.java
@@ -26,10 +26,15 @@ package org.jenkinsci.plugins.pipeline.milestone;
 import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.actions.StageAction;
 
+/**
+ * @deprecated Only for loading historical builds.
+ */
+@Deprecated
 class MilestoneAction extends LabelAction implements StageAction {
 
-    MilestoneAction(String label) {
-        super(label);
+    private MilestoneAction() {
+        super(null);
+        throw new AssertionError("no longer constructed");
     }
 
     @Override 

--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -40,6 +40,7 @@ import edu.umd.cs.findbugs.annotations.CheckForNull;
 import com.google.common.base.Predicate;
 import hudson.model.Item;
 import hudson.model.listeners.ItemListener;
+import org.jenkinsci.plugins.workflow.actions.LabelAction;
 import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.graphanalysis.FlowScanningUtils;
@@ -74,7 +75,7 @@ public class MilestoneStepExecution extends AbstractSynchronousStepExecution<Voi
     @Override
     public Void run() throws Exception {
         if (step.getLabel() != null) {
-            node.addAction(new MilestoneAction(step.getLabel()));
+            node.addAction(new LabelAction(step.getLabel()));
         }
         int ordinal = processOrdinal();
         tryToPass(run, getContext(), ordinal);


### PR DESCRIPTION
Aligns with https://github.com/jenkinsci/pipeline-stage-step-plugin/pull/94 and anticipates proposed deprecation in https://github.com/jenkinsci/workflow-api-plugin/pull/274. The practical impact would just be that `milestone`s no longer appear as “stages” for purposes of certain Pipeline visualizations trained to expect non-block-scoped `stage`. Normal usage would be in conjunction with block-scoped `stage`.