### PR TITLE
Fix CleaupJobsTest.noNPEOnCleanup for 2.509 and later

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/pipeline/milestone/CleaupJobsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/milestone/CleaupJobsTest.java
@@ -65,7 +65,7 @@ public class CleaupJobsTest {
         LogRecorder recorder = new LogRecorder("recorder");
         LogRecorderManager mgr = j.jenkins.getLog();
         LogRecorder.Target t = new LogRecorder.Target(ItemListener.class.getName(), Level.ALL);
-        recorder.targets.add(t);
+        recorder.getLoggers().add(t);
         recorder.save();
         t.enable();
         mgr.logRecorders.put("recorder", recorder);


### PR DESCRIPTION
## Fix CleaupJobsTest.noNPEOnCleanup for 2.509 and later

The LogRecorder targets field was deprecated over 3 years ago.  It is removed in Jenkins 2.509.  The [documentation](https://javadoc.jenkins.io/hudson/logging/LogRecorder.html#targets) recommends getLoggers() as its replacement.

Fixes the automated test with Jenkins 2.509 so that the Jenkins plugin BOM and other PCT based environments can continue to test with the latest weekly release.

### Testing done

* Without this change, the tests fail to compile with Jenkins 2.509
* With this change, the tests pass with Jenkins 2.509
* With this change, the tests pass with other Jenkins versions as well

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
