### PR TITLE
Use parent pom 5.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>5.14</version>
+        <version>5.16</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Use parent pom 5.16

The plugin bill of materials fails to run tests with parent pom versions 5.13 through 5.15.  Details are available in https://github.com/jenkinsci/bom/pull/5000#issuecomment-2852005108 and in the related pull requests:

* https://github.com/jenkinsci/maven-hpi-plugin/pull/741
* https://github.com/jenkinsci/plugin-pom/pull/1138

Needs to be labeled `developer` so that a new release is delivered

### Testing done

Confirmed that `mvn clean verify` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
