### PR TITLE
Don't cancel previous builds at later milestones on build completion

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepExecution.java
@@ -201,7 +201,7 @@ public class MilestoneStepExecution extends SynchronousStepExecution<Void> {
                 LOGGER.finest(() -> "milestones after completion: " + result.milestones());
                 if (result.lastMilestoneBeforeCompletion() != null) {
                     LOGGER.finest(() -> "Build" + r + " last milestone before completion: " + result.lastMilestoneBeforeCompletion());
-                    var buildsToCancel = getBuildsToCancel(r.getNumber(), Integer.MAX_VALUE, result.milestones());
+                    var buildsToCancel = getBuildsToCancel(r.getNumber(), result.lastMilestoneBeforeCompletion() + 1, result.milestones());
                     cancelAll(r.getParent(), buildsToCancel);
                 } else {
                     LOGGER.finest(() -> "Build " + r + " was not using milestones, nothing to cancel");

--- a/src/test/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepTest.java
@@ -440,8 +440,10 @@ public class MilestoneStepTest {
         WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("wait_a/1", b1);
         
-        // Let #1 continue
+        // Let #1 continue until the the second milestone
         SemaphoreStep.success("wait_a/1", null);
+        SemaphoreStep.waitForStart("wait_b/1", b1);
+
         WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
         SemaphoreStep.waitForStart("wait_a/2", b2);        
         

--- a/src/test/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/pipeline/milestone/MilestoneStepTest.java
@@ -423,4 +423,37 @@ public class MilestoneStepTest {
             r.assertLogNotContains("Passed first milestone", b1);
         });
     }
+
+    @Issue("JENKINS-75668")
+    @Test
+    public void olderBuildsAtLaterMilestonesMustNotBeCancelledOnBuildFinish() throws Throwable {
+      story.then(r -> {
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition(
+                """
+                        milestone()
+                        semaphore 'wait_a'
+                        if (currentBuild.number == 2) { error 'failure' }
+                        milestone()
+                        semaphore 'wait_b'
+                        """, true));
+        WorkflowRun b1 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait_a/1", b1);
+        
+        // Let #1 continue
+        SemaphoreStep.success("wait_a/1", null);
+        WorkflowRun b2 = p.scheduleBuild2(0).waitForStart();
+        SemaphoreStep.waitForStart("wait_a/2", b2);        
+        
+        // Let #2 continue and error
+        SemaphoreStep.success("wait_a/2", null);
+        r.assertBuildStatus(Result.FAILURE, r.waitForCompletion(b2));
+
+        // Let #1 finish
+        SemaphoreStep.success("wait_b/1", null);
+
+        // Confirm that #1 was not canceled
+        r.assertBuildStatus(Result.SUCCESS, r.waitForCompletion(b1));
+    });
+    }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fix for [JENKINS-75668](https://issues.jenkins.io/browse/JENKINS-75668) which is a regression introduced by https://github.com/jenkinsci/pipeline-milestone-step-plugin/pull/147.

When a build completes only cancel previous builds at the same or earlier milestones. Previous running builds at later milestones should not be canceled.

I backported the new test to d50e283c65e7106c51d794d079dbc08ec9b59d1a to confirm it passed before b52887ca3b6d69a0fc25bcc61e4c063fd52b0bb8.

Desired reviewers: @jglick @Vlatombe

### Testing done

Added a new test [`olderBuildsAtLaterMilestonesMustNotBeCancelledOnBuildFinish()`](https://github.com/jenkinsci/pipeline-milestone-step-plugin/compare/master...stuartrowe:pipeline-milestone-step-plugin:JENKINS-75668?expand=1#diff-9dd3955ec64dcfd0747a36bebc6c24d8218dfdffc1271d5b670d6e8f5acb5cd0R429-R458) demonstrating the issue.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
